### PR TITLE
Added babel-plugins-add-module-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-eslint": "^4.1.5",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
+    "babel-plugin-add-module-exports": "^0.1.1",
     "babelify": "^7.2.0",
     "browserify": "^12.0.1",
     "chai": "^3.4.1",
@@ -63,6 +64,9 @@
     "presets": [
       "react",
       "es2015"
+    ],
+    "plugins": [
+      "add-module-exports"
     ]
   }
 }


### PR DESCRIPTION
For compatibility for using require() in non-ES6 environment.
No need for require('react-split-plane').default