### PR TITLE
Add onDragFinished property

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -87,9 +87,14 @@ export default React.createClass({
 
 
     onMouseUp() {
-        this.setState({
-            active: false
-        });
+        if (this.state.active) {
+            if (this.props.onDragFinished) {
+                this.props.onDragFinished();
+            }
+            this.setState({
+                active: false
+            });
+        }
     },
 
 


### PR DESCRIPTION
Enables tapping into the resize finished event, could help with issue https://github.com/tomkp/react-split-pane/issues/30