### PR TITLE
Resizing callbacks type check + ReadMe update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ https://github.com/mozilla/localForage although hooking it up will be slightly
 more involved.  You are likely to be admired by all for judiciously avoiding
 use of localStorage.
 
+### Resizing callbacks
+
+If you need more control over resizing, SplitPane can notify you about when resizing started
+and when it ended through two callbacks: `onDragStarted` and `onDragFinished`.
+
 ### Example styling
 
 This gives a single pixel wide divider, but with a 'grabbable' surface of 11 pixels.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "chai": "^3.5.0",
+    "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
     "express": "^4.13.4",
     "mochify": "^2.17.0",

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -11,7 +11,9 @@ export default React.createClass({
 
     propTypes: {
         primary: React.PropTypes.oneOf(['first', 'second']),
-        split: React.PropTypes.oneOf(['vertical', 'horizontal'])
+        split: React.PropTypes.oneOf(['vertical', 'horizontal']),
+        onDragStarted: React.PropTypes.func,
+        onDragFinished: React.PropTypes.func,
     },
 
     getInitialState() {
@@ -52,8 +54,8 @@ export default React.createClass({
     onMouseDown(event) {
         this.unFocus();
         let position = this.props.split === 'vertical' ? event.clientX : event.clientY;
-        if (this.props.onDragStart) {
-            this.props.onDragStart();
+        if (typeof this.props.onDragStarted === 'function') {
+            this.props.onDragStarted();
         }
         this.setState({
             active: true,
@@ -86,7 +88,7 @@ export default React.createClass({
                     if (newSize < this.props.minSize) {
                         newSize = this.props.minSize;
                     }
-                    
+
                     if (this.props.onChange) {
                       this.props.onChange(newSize);
                     }
@@ -101,7 +103,7 @@ export default React.createClass({
 
     onMouseUp() {
         if (this.state.active) {
-            if (this.props.onDragFinished) {
+            if (typeof this.props.onDragFinished === 'function') {
                 this.props.onDragFinished();
             }
             this.setState({

--- a/test/assertions/Asserter.js
+++ b/test/assertions/Asserter.js
@@ -4,9 +4,12 @@ import SplitPane from '../../lib/SplitPane';
 import Resizer from '../../lib/Resizer';
 import Pane from '../../lib/Pane';
 import chai from 'chai';
+import spies from 'chai-spies';
 const expect = chai.expect;
 import VendorPrefix from 'react-vendor-prefix';
 import ReactTestUtils from 'react-addons-test-utils';
+
+chai.use(spies);
 
 /**
  * getBoundingClientRect() does not work correctly with ReactTestUtils.renderIntoDocument().
@@ -72,6 +75,12 @@ export default (jsx, renderToDom = false) => {
     };
 
 
+    const assertCallbacks = (expectedDragStartedCallback, expectedDragFinishedCallback) => {
+        expect(expectedDragStartedCallback).to.have.been.called();
+        expect(expectedDragFinishedCallback).to.have.been.called();
+    };
+
+
     const getResizerPosition = () => {
         const resizerNode = ReactDOM.findDOMNode(findResizer()[0]);
         return resizerNode.getBoundingClientRect();
@@ -119,16 +128,16 @@ export default (jsx, renderToDom = false) => {
         },
 
         assertSplitPaneClass(expectedClassName) {
-          assertClass(component, expectedClassName);  
+          assertClass(component, expectedClassName);
         },
 
-        
+
         assertPaneClasses(expectedTopPaneClass, expectedBottomPaneClass) {
             assertClass(findTopPane(), expectedTopPaneClass);
             assertClass(findBottomPane(), expectedBottomPaneClass);
         },
 
-        
+
         assertPaneContents(expectedContents) {
             const panes = findPanes();
             let values = panes.map((pane) => {
@@ -159,6 +168,11 @@ export default (jsx, renderToDom = false) => {
         assertResizeByDragging(mousePositionDifference, expectedStyle) {
             simulateDragAndDrop(mousePositionDifference);
             return assertPaneStyles(expectedStyle, component.props.primary);
+        },
+
+        assertResizeCallbacks(expectedDragStartedCallback, expectedDragFinishedCallback) {
+            simulateDragAndDrop(200);
+            return assertCallbacks(expectedDragStartedCallback, expectedDragFinishedCallback);
         }
     }
 }

--- a/test/default-split-pane-tests.js
+++ b/test/default-split-pane-tests.js
@@ -2,8 +2,10 @@ import React from 'react';
 import SplitPane from '../lib/SplitPane';
 import Resizer from '../lib/Resizer';
 import asserter from './assertions/Asserter';
+import chai from 'chai';
+import spies from 'chai-spies';
 
-
+chai.use(spies);
 
 describe('Default SplitPane', function () {
 
@@ -26,7 +28,7 @@ describe('Default SplitPane', function () {
     it('should contain a Resizer', function () {
          asserter(splitPane).assertContainsResizer();
     });
-    
+
 });
 
 
@@ -42,6 +44,31 @@ describe('SplitPane can have a specific class', function () {
 
     it('should have the specified class', function () {
         asserter(splitPane).assertSplitPaneClass('some-class');
+    });
+
+});
+
+
+describe('SplitPane can have resizing callbacks', function () {
+    const onDragStartedCallback = chai.spy(function() { });
+    const onDragFinishedCallback = chai.spy(function() { });
+
+    const splitPane = (
+        <SplitPane className="some-class"
+          onDragStarted = { onDragStartedCallback }
+          onDragFinished = { onDragFinishedCallback }
+        >
+            <div>one</div>
+            <div>two</div>
+        </SplitPane>
+    );
+
+
+    it('should call callbacks on resizing', function () {
+        asserter(splitPane).assertResizeCallbacks(
+          onDragStartedCallback,
+          onDragFinishedCallback
+        );
     });
 
 });


### PR DESCRIPTION
In this PR: 
- `onDragStart` renamed to `onDragStarted` (to match `onDragFinished` - past tense sounds better)
- More specific type checks for `onDragStarted` adn `onDragFinished`
- ReadMe updated since I almost gave up on this component thinking there are no callbacks for resizing events
- Tests for the resizing callbacks