### PR TITLE
Fixed travis PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 - sudo mv phantomjs /usr/local/phantomjs/bin/phantomjs
 after_script:
 - npm run test:coverage
-- npm run demo:publish
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run demo:publish || false'


### PR DESCRIPTION
Now PRs will not be tried to publish to surge, which causes failure (since PRs are not authorised to do so)

See https://docs.travis-ci.com/user/pull-requests for additional details