### PR TITLE
extension-of-maxSize-param-behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ In this example right pane keeps its width 200px while user is resizing browser 
     </SplitPane>
 ```
 
+### maxSize
+You can limit the maximal size of the 'fixed' pane using the maxSize parameter with a positive value (mesured in pixels but state just a number).
+If you wrap the SplitPane into a container component (yes you can, just remember the container has to have the relative or absolute positioning), 
+then you'll need to limit the movement of the splitter (resizer) at the end of the SplitPane (otherwise it can be dragged outside the SplitPane 
+and you don't catch it never more). For this purpose use the maxSize parameter with value 0. When dragged the splitter/resizer will stop at the border 
+of the SplitPane component and thank this you'll be able to pick it again and drag it back then.
+And more: if you set the maxSize to negative value (e.g. -200), then the splitter stops 200px before the border (in other words it sets the minimal 
+size of the 'resizable' pane in this case). This can be useful also in the full-screen case of use.
+
 ### Persisting Positions
 
 Each SplitPane accepts an onChange function prop.  Used in conjunction with

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -65,12 +65,22 @@ class SplitPane extends Component {
                         const position = this.state.position;
                         const newPosition = isPrimaryFirst ? (position - current) : (current - position);
 
+                        let maxSize = this.props.maxSize;
+                        if ((this.props.maxSize !== undefined) && (this.props.maxSize <= 0)) {
+                            const splPane = ReactDOM.findDOMNode(this.refs.splitPane);
+                            if (this.props.split === 'vertical') {
+                                maxSize = splPane.getBoundingClientRect().width + this.props.maxSize;
+                            } else {
+                                maxSize = splPane.getBoundingClientRect().height + this.props.maxSize;
+                            }
+                        }
+
                         let newSize = size - newPosition;
 
                         if (newSize < this.props.minSize) {
                             newSize = this.props.minSize;
-                        } else if (newSize > this.props.maxSize) {
-                            newSize = this.props.maxSize;
+                        } else if ((this.props.maxSize !== undefined) && (newSize > maxSize)) {
+                            newSize = maxSize;
                         } else {
                             this.setState({
                                 position: current,


### PR DESCRIPTION
If you wrap the SplitPane into a container component then
you'll need to limit the movement of the splitter (resizer) at the end
of the SplitPane (otherwise it can be dragged outside the SplitPane and
you don't catch it never more). For this purpose use the maxSize
parameter with value 0. When dragged the splitter/resizer will stop at
the border of the SplitPane component and thank this you'll be able to
pick it again and drag it back then.
And more: if you set the maxSize to negative value (e.g. -200), then the
splitter stops 200px before the border (in other words it sets the
minimal size of the 'resizable' pane in this case). This can be useful
also in the full-screen case of use.