### PR TITLE
Move babel config out of package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "react",
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports",
+    "transform-object-assign"
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src/
+.babelrc

--- a/package.json
+++ b/package.json
@@ -63,15 +63,5 @@
         "babelify"
       ]
     ]
-  },
-  "babel": {
-    "presets": [
-      "react",
-      "es2015"
-    ],
-    "plugins": [
-      "add-module-exports",
-      "transform-object-assign"
-    ]
   }
 }


### PR DESCRIPTION
It was causing errors in consuming packages which did not have those babel plugins installed.

Fixes #77