### PR TITLE
Apply default size to panes on first render

### DIFF
--- a/src/Pane.js
+++ b/src/Pane.js
@@ -8,7 +8,7 @@ class Pane extends Component {
     constructor(...args) {
         super(...args);
 
-        this.state = {};
+        this.state = { size: this.props.size };
     }
 
     render() {
@@ -43,6 +43,10 @@ Pane.propTypes = {
     children: PropTypes.node.isRequired,
     prefixer: PropTypes.instanceOf(Prefixer).isRequired,
     style: stylePropType,
+    size: PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number,
+    ]),
 };
 
 Pane.defaultProps = {

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -233,6 +233,10 @@ class SplitPane extends Component {
                     key="pane1" className="Pane1"
                     style={pane1Style}
                     split={split}
+                    size={this.props.primary === 'first' ?
+                      this.props.size || this.props.defaultSize || this.props.minSize :
+                      undefined
+                    }
                 >
                     {children[0]}
                 </Pane>
@@ -252,6 +256,10 @@ class SplitPane extends Component {
                     className="Pane2"
                     style={pane2Style}
                     split={split}
+                    size={this.props.primary === 'second' ?
+                      this.props.size || this.props.defaultSize || this.props.minSize :
+                      undefined
+                    }
                 >
                     {children[1]}
                 </Pane>


### PR DESCRIPTION
**The problem**
Currently, pane size is applied when `this.setSize()` is called from `componentDidMount()` when happens after SplitPane renders: https://github.com/tomkp/react-split-pane/blob/2fd066ea75fa193ea46f9c0cfc3a645d64b325fb/src/SplitPane.js#L36. 

This causes a pane to render initially without the correct size and any children placed inside a pane will get the wrong size on the first render. 

**Solution**
This can be fixed by: 

1. Provide initial size to Panes as prop (https://github.com/ImperialCollegeLondon/react-split-pane/commit/d435e0b1be090389d563f365bcba4065431752e6)
2. Set initial state size to default size provided in props (https://github.com/ImperialCollegeLondon/react-split-pane/commit/4fa5cccff7df88e0dc51ecdfca7dca9c6b6c8ae7)