### PR TITLE
allow setting size to 0 from props

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -160,7 +160,7 @@ class SplitPane extends Component {
         const ref = this.props.primary === 'first' ? this.pane1 : this.pane2;
         let newSize;
         if (ref) {
-            newSize = props.size || (state && state.draggedSize) || props.defaultSize || props.minSize;
+            newSize = (props.size === undefined) || (state && state.draggedSize) || props.defaultSize || props.minSize;
             ref.setState({
                 size: newSize,
             });

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -160,7 +160,7 @@ class SplitPane extends Component {
         const ref = this.props.primary === 'first' ? this.pane1 : this.pane2;
         let newSize;
         if (ref) {
-            newSize = (props.size === undefined) || (state && state.draggedSize) || props.defaultSize || props.minSize;
+            newSize = (props.size !== undefined && props.size) || (state && state.draggedSize) || props.defaultSize || props.minSize;
             ref.setState({
                 size: newSize,
             });


### PR DESCRIPTION
Currently if you set `size` to 0 in props, the pane won't collapse because `setSize()` thinks it should fall back to the last dragged position.