### PR TITLE
Add demo/ and test/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 src/
 .babelrc
+demo/
+test/


### PR DESCRIPTION
The demos don't have to be published inside the npm module.

The `demo/` folder has a size of 2.3 MB and is the main contributor to the big module size of 3 MB (with all dependencies). This PR removes it.