### PR TITLE
update to inline-style-prefixer@^3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "es6"
   ],
   "dependencies": {
-    "inline-style-prefixer": "^3.0.2",
+    "inline-style-prefixer": "^3.0.5",
     "prop-types": "^15.5.8",
     "react-style-proptype": "^3.0.0"
   },


### PR DESCRIPTION
Pull Request for https://github.com/tomkp/react-split-pane/issues/199

`inline-style-prefixer` updated their package removing the `caniuse-api` dependency in `v3.0.5`