### PR TITLE
Make user-supplied resizerClassName prop additive

### DIFF
--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -4,6 +4,7 @@ import Prefixer from 'inline-style-prefixer';
 import stylePropType from 'react-style-proptype';
 
 const USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Safari/537.2';
+export const RESIZER_DEFAULT_CLASSNAME = 'Resizer';
 
 class Resizer extends React.Component {
     render() {
@@ -56,7 +57,7 @@ Resizer.propTypes = {
 
 Resizer.defaultProps = {
     prefixer: new Prefixer({ userAgent: USER_AGENT }),
-    resizerClassName: 'Resizer',
+    resizerClassName: RESIZER_DEFAULT_CLASSNAME,
 };
 
 export default Resizer;

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -167,7 +167,8 @@ class SplitPane extends React.Component {
             pane1Style: pane1StyleProps, pane2Style: pane2StyleProps, primary, prefixer, resizerClassName,
             resizerStyle, size, split, style: styleProps } = this.props;
         const disabledClass = allowResize ? '' : 'disabled';
-	const resizerClassNamesIncludingDefault = (resizerClassName ? resizerClassName + ' ' + RESIZER_DEFAULT_CLASSNAME : resizerClassName);
+        const resizerClassNamesIncludingDefault = (resizerClassName ?
+              `${resizerClassName} ${RESIZER_DEFAULT_CLASSNAME}` : resizerClassName);
 
         const style = Object.assign({},
             styleProps || {}, {

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -5,7 +5,7 @@ import Prefixer from 'inline-style-prefixer';
 import stylePropType from 'react-style-proptype';
 
 import Pane from './Pane';
-import Resizer from './Resizer';
+import Resizer, { RESIZER_DEFAULT_CLASSNAME } from './Resizer';
 
 const USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Safari/537.2';
 
@@ -167,6 +167,7 @@ class SplitPane extends React.Component {
             pane1Style: pane1StyleProps, pane2Style: pane2StyleProps, primary, prefixer, resizerClassName,
             resizerStyle, size, split, style: styleProps } = this.props;
         const disabledClass = allowResize ? '' : 'disabled';
+	const resizerClassNamesIncludingDefault = (resizerClassName ? resizerClassName + ' ' + RESIZER_DEFAULT_CLASSNAME : resizerClassName);
 
         const style = Object.assign({},
             styleProps || {}, {
@@ -227,7 +228,7 @@ class SplitPane extends React.Component {
                     onTouchEnd={this.onMouseUp}
                     key="resizer"
                     ref={(node) => { this.resizer = node; }}
-                    resizerClassName={resizerClassName}
+                    resizerClassName={resizerClassNamesIncludingDefault}
                     split={split}
                     style={resizerStyle || {}}
                 />

--- a/test/default-split-pane-tests.js
+++ b/test/default-split-pane-tests.js
@@ -107,5 +107,9 @@ describe('Internal Resizer have class', () => {
     it('should have the specified classname', () => {
         asserter(splitPane).assertResizerClasses('some-class');
     });
+    
+    it('should have the default classname', () => {
+        asserter(splitPane).assertResizerClasses('Resizer');
+    });
 
 });


### PR DESCRIPTION
If a resizerClassName prop is supplied by the user, make it additive to the default class name (instead of completely replacing it).