### PR TITLE
feat: Allow passing class names to Pane components

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -263,7 +263,7 @@ class SplitPane extends React.Component {
         style={prefixer.prefix(style)}
       >
         <Pane
-          className="Pane1"
+          className={pane1ClassName}
           key="pane1"
           ref={node => {
             this.pane1 = node;
@@ -292,7 +292,7 @@ class SplitPane extends React.Component {
           style={resizerStyle || {}}
         />
         <Pane
-          className="Pane2"
+          className={pane2ClassName}
           key="pane2"
           ref={node => {
             this.pane2 = node;

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -187,13 +187,13 @@ class SplitPane extends React.Component {
       allowResize,
       children,
       className,
-      paneClassName,
-      pane1ClassName,
-      pane2ClassName,
       defaultSize,
       minSize,
       onResizerClick,
       onResizerDoubleClick,
+      paneClassName,
+      pane1ClassName,
+      pane2ClassName,
       paneStyle,
       pane1Style: pane1StyleProps,
       pane2Style: pane2StyleProps,
@@ -251,8 +251,8 @@ class SplitPane extends React.Component {
       Object.assign({}, paneStyle || {}, pane2StyleProps || {})
     );
 
-    const pane1classes = ['Pane1', paneClassName, pane1ClassName];
-    const pane2classes = ['Pane2', paneClassName, pane2ClassName];
+    const pane1ClassName = ['Pane1', paneClassName, pane1ClassName];
+    const pane2ClassName = ['Pane2', paneClassName, pane2ClassName];
    
     return (
       <div
@@ -329,6 +329,9 @@ SplitPane.propTypes = {
   prefixer: PropTypes.instanceOf(Prefixer).isRequired,
   style: stylePropType,
   resizerStyle: stylePropType,
+  paneClassName: PropTypes.string,
+  pane1ClassName: PropTypes.string,
+  pane2ClassName: PropTypes.string,
   paneStyle: stylePropType,
   pane1Style: stylePropType,
   pane2Style: stylePropType,

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -251,8 +251,8 @@ class SplitPane extends React.Component {
       Object.assign({}, paneStyle || {}, pane2StyleProps || {})
     );
 
-    const pane1Classes = ['Pane1', paneClassName, pane1ClassName];
-    const pane2Classes = ['Pane2', paneClassName, pane2ClassName];
+    const pane1Classes = ['Pane1', paneClassName, pane1ClassName].join(' ');
+    const pane2Classes = ['Pane2', paneClassName, pane2ClassName].join(' ');
    
     return (
       <div
@@ -345,6 +345,9 @@ SplitPane.defaultProps = {
   prefixer: new Prefixer({ userAgent: USER_AGENT }),
   primary: 'first',
   split: 'vertical',
+  paneClassName: '',
+  pane1ClassName: '',
+  pane2ClassName: '',
 };
 
 export default SplitPane;

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -251,8 +251,8 @@ class SplitPane extends React.Component {
       Object.assign({}, paneStyle || {}, pane2StyleProps || {})
     );
 
-    const pane1ClassName = ['Pane1', paneClassName, pane1ClassName];
-    const pane2ClassName = ['Pane2', paneClassName, pane2ClassName];
+    const pane1Classes = ['Pane1', paneClassName, pane1ClassName];
+    const pane2Classes = ['Pane2', paneClassName, pane2ClassName];
    
     return (
       <div
@@ -263,7 +263,7 @@ class SplitPane extends React.Component {
         style={prefixer.prefix(style)}
       >
         <Pane
-          className={pane1ClassName}
+          className={pane1Classes}
           key="pane1"
           ref={node => {
             this.pane1 = node;
@@ -292,7 +292,7 @@ class SplitPane extends React.Component {
           style={resizerStyle || {}}
         />
         <Pane
-          className={pane2ClassName}
+          className={pane2Classes}
           key="pane2"
           ref={node => {
             this.pane2 = node;

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -187,6 +187,9 @@ class SplitPane extends React.Component {
       allowResize,
       children,
       className,
+      paneClassName,
+      pane1ClassName,
+      pane2ClassName,
       defaultSize,
       minSize,
       onResizerClick,
@@ -248,6 +251,9 @@ class SplitPane extends React.Component {
       Object.assign({}, paneStyle || {}, pane2StyleProps || {})
     );
 
+    const pane1classes = ['Pane1', paneClassName, pane1ClassName];
+    const pane2classes = ['Pane2', paneClassName, pane2ClassName];
+   
     return (
       <div
         className={classes.join(' ')}

--- a/test/assertions/Asserter.js
+++ b/test/assertions/Asserter.js
@@ -142,6 +142,14 @@ export default (jsx, renderToDom = false) => {
       assertClass(findBottomPane(), expectedBottomPaneClass);
     },
 
+    assertTopPaneClasses(expectedTopPaneClass) {
+      assertClass(findTopPane(), expectedTopPaneClass);
+    },
+
+    assertBottomPaneClasses(expectedBottomPaneClass) {
+      assertClass(findBottomPane(), expectedBottomPaneClass);
+    },
+
     assertPaneContents(expectedContents) {
       const panes = findPanes();
       const values = panes.map(pane => findDOMNode(pane).textContent);

--- a/test/default-split-pane-tests.js
+++ b/test/default-split-pane-tests.js
@@ -66,14 +66,52 @@ describe('SplitPane can have resizing callbacks', () => {
 
 describe('Internal Panes have class', () => {
   const splitPane = (
-    <SplitPane className="some-class">
+    <SplitPane paneClassName="some-class">
       <div>one</div>
       <div>two</div>
     </SplitPane>
   );
 
   it('should have the specified classname', () => {
+    asserter(splitPane).assertPaneClasses('some-class', 'some-class');
+  });
+
+  it('should have the default classname', () => {
     asserter(splitPane).assertPaneClasses('Pane1', 'Pane2');
+  });
+});
+
+describe('Top/Left Pane have class', () => {
+  const splitPane = (
+    <SplitPane pane1ClassName="some-class">
+      <div>one</div>
+      <div>two</div>
+    </SplitPane>
+  );
+
+  it('should have the specified classname', () => {
+    asserter(splitPane).assertTopPaneClasses('some-class');
+  });
+
+  it('should have the default classname', () => {
+    asserter(splitPane).assertTopPaneClasses('Pane1');
+  });
+});
+
+describe('Bottom/Right Pane have class', () => {
+  const splitPane = (
+    <SplitPane pane2ClassName="some-class">
+      <div>one</div>
+      <div>two</div>
+    </SplitPane>
+  );
+
+  it('should have the specified classname', () => {
+    asserter(splitPane).assertBottomPaneClasses('some-class');
+  });
+
+  it('should have the default classname', () => {
+    asserter(splitPane).assertBottomPaneClasses('Pane2');
   });
 });
 


### PR DESCRIPTION
Adds `paneClassName` and `pane1ClassName`/`pane2ClassName` variants to match up with the `paneStyle` prop. Useful for those of us who don't specify inline styles but use CSS/SASS/LESS