### PR TITLE
Use PureComponent

### DIFF
--- a/src/Pane.js
+++ b/src/Pane.js
@@ -8,7 +8,7 @@ const DEFAULT_USER_AGENT =
 const USER_AGENT =
   typeof navigator !== 'undefined' ? navigator.userAgent : DEFAULT_USER_AGENT;
 
-class Pane extends React.Component {
+class Pane extends React.PureComponent {
   constructor(props) {
     super(props);
 

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -9,7 +9,7 @@ const USER_AGENT =
   typeof navigator !== 'undefined' ? navigator.userAgent : DEFAULT_USER_AGENT;
 export const RESIZER_DEFAULT_CLASSNAME = 'Resizer';
 
-class Resizer extends React.Component {
+class Resizer extends React.PureComponent {
   render() {
     const {
       className,

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -23,7 +23,7 @@ function unFocus(document, window) {
   }
 }
 
-class SplitPane extends React.Component {
+class SplitPane extends React.PureComponent {
   constructor() {
     super();
 


### PR DESCRIPTION
We've noticed a lot of updates coming from `react-split-pane` when testing using https://github.com/maicki/why-did-you-update .  Switching to `PureComponent` may help with this.