### PR TITLE
Peg @types/react version to version of react [not ready to merge - requires further actions]

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "@types/inline-style-prefixer": "^3.0.0",
-    "@types/react": "^16.0.18",
+    "@types/react": "^15.6.1",
     "inline-style-prefixer": "^3.0.6",
     "prop-types": "^15.5.10",
     "react-style-proptype": "^3.0.0"


### PR DESCRIPTION
The version of @types/* should always be pegged to the version of the package being used.

 In this case, having types for React 16 in a project using React 15 is resulting in type errors.

**BLOCKER**
@tomkp I tried running `npm install` to update the package-lock.json, but that gave me a much larger diff than expected. It might have something to do with the version of npm (I am using v5.6.0). If you let me know which version of npm you are using, I can update package-lock.json using that version. Alternately, you can make the changes yourself. Thanks! :)
  