### PR TITLE
Unset the size on the non-primary Pane if primary pane changes

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -170,8 +170,9 @@ class SplitPane extends React.Component {
   }
 
   setSize(props, state) {
-    const { primary } = this.props;
-    const ref = primary === 'first' ? this.pane1 : this.pane2;
+    const isPrimaryFirst = props.primary === 'first';
+    const ref = isPrimaryFirst ? this.pane1 : this.pane2;
+    const ref2 = isPrimaryFirst ? this.pane2 : this.pane1;
     let newSize;
     if (ref) {
       newSize =
@@ -187,6 +188,11 @@ class SplitPane extends React.Component {
           draggedSize: newSize,
         });
       }
+    }
+    if (ref2 && props.primary !== this.props.primary) {
+      ref2.setState({
+        size: undefined,
+      });
     }
   }
 

--- a/test/assertions/Asserter.js
+++ b/test/assertions/Asserter.js
@@ -43,6 +43,10 @@ export default (jsx, renderToDom = false) => {
   const findResizer = () =>
     ReactTestUtils.scryRenderedComponentsWithType(splitPane, Resizer);
 
+  const updateComponent = newJsx =>
+    render(newJsx, findDOMNode(splitPane).parentNode);
+
+
   const assertStyles = (componentName, actualStyles, expectedStyles) => {
     Object.keys(expectedStyles).forEach(prop => {
       // console.log(`${prop}: '${actualStyles[prop]}',`);
@@ -203,6 +207,16 @@ export default (jsx, renderToDom = false) => {
 
     assertResizerClasses(expectedClass) {
       assertClass(findResizer()[0], expectedClass);
+    },
+    
+    assertPrimaryPanelChange(newJsx, primaryPane, secondaryPane) {
+      const primary = findPaneByOrder(primaryPane);
+      const secondary = findPaneByOrder(secondaryPane);
+      expect(primary.state.size).to.equal(50);
+      expect(secondary.state.size).to.equal(undefined);
+      updateComponent(newJsx);
+      expect(primary.state.size).to.equal(undefined);
+      expect(secondary.state.size).to.equal(50);
     },
   };
 };

--- a/test/default-split-pane-tests.js
+++ b/test/default-split-pane-tests.js
@@ -131,3 +131,26 @@ describe('Internal Resizer have class', () => {
     asserter(splitPane).assertResizerClasses('Resizer');
   });
 });
+
+describe('Component updates', () => {
+  const splitPane1 = (
+    <SplitPane primary="first">
+      <div>one</div>
+      <div>two</div>
+    </SplitPane>
+  );
+  const splitPane2 = (
+    <SplitPane primary="second">
+      <div>one</div>
+      <div>two</div>
+    </SplitPane>
+  );
+  
+  it('unsets the width on the non-primary panel when first', () => {
+    asserter(splitPane1).assertPrimaryPanelChange(splitPane2, 'first', 'second');
+  });
+
+  it('unsets the width on the non-primary panel when second', () => {
+    asserter(splitPane2).assertPrimaryPanelChange(splitPane1, 'second', 'first');
+  });
+});


### PR DESCRIPTION
If the primary pane changes, the old primary's size gets stuck. This PR should fix this. 