### PR TITLE
add es for export default,  resolve “Typescript types are ’inverted‘“

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -1,0 +1,3 @@
+import SplitPane from '../lib/SplitPane';
+
+export default SplitPane;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-split-pane",
   "description": "React split-pane component",
   "main": "index.js",
+  "module": "es/index",
   "types": "index.d.ts",
   "version": "0.1.74",
   "repository": {


### PR DESCRIPTION
add es/index.js for export default. 
resolve the error 'React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components)  ...' in typescript