### PR TITLE
Fix top-level export in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,4 +50,4 @@ declare class SplitPane extends React.Component<Props, State> {
     static defaultProps: Props;
 }
 
-export { SplitPane as default };
+export = SplitPane;


### PR DESCRIPTION
Fixes #244
Fixes #245
Obviates #247
See https://github.com/DefinitelyTyped/DefinitelyTyped#a-package-uses-export--but-i-prefer-to-use-default-imports-can-i-change-export--to-export-default