### PR TITLE
[v2] fix typo on calculatePositionBetween

### DIFF
--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -30,7 +30,7 @@ export const calculatePointsBetween = (from, to) => {
   let sy = (y0 < y1) ? 1 : -1;
   let err = dx - dy;
 
-  coordinates.push({ x: x0, y: y0 });
+  coordinates.push({ clientX: x0, clientY: y0 });
 
   while (!((x0 === x1) && (y0 === y1))) {
     let e2 = err << 1;


### PR DESCRIPTION
There was a typo on pushing the first position element.

for input `{clientX: 0, clientY: 0}, {clientX: 10, clientY: 20}`,
result:
```js
{"x":0,"y":0}
{"clientX":0,"clientY":1}
{"clientX":1,"clientY":2}
{"clientX":1,"clientY":3}
// ...
{"clientX":9,"clientY":18}
{"clientX":9,"clientY":19}
{"clientX":10,"clientY":20}
```

expected:
```js
{"clientX":0,"clientY":0}
{"clientX":0,"clientY":1}
{"clientX":1,"clientY":2}
{"clientX":1,"clientY":3}
// ...
{"clientX":9,"clientY":18}
{"clientX":9,"clientY":19}
{"clientX":10,"clientY":20}
```