### PR TITLE
Avoid inconsistent state when changing `props.size`

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -175,15 +175,14 @@ class SplitPane extends React.Component {
     const ref2 = isPrimaryFirst ? this.pane2 : this.pane1;
     let newSize;
     if (ref) {
-      newSize =
-        props.size ||
-        (state && state.draggedSize) ||
-        props.defaultSize ||
-        props.minSize;
+      newSize = (props.size !== undefined
+        ? props.size
+        : getDefaultSize(props.defaultSize, props.minSize, props.maxSize, state.draggedSize)
+      );
       ref.setState({
         size: newSize,
       });
-      if (props.size !== state.draggedSize) {
+      if ((props.size !== undefined) && (props.size !== state.draggedSize)) {
         this.setState({
           draggedSize: newSize,
         });
@@ -193,6 +192,16 @@ class SplitPane extends React.Component {
       ref2.setState({
         size: undefined,
       });
+    }
+
+    function getDefaultSize(defaultSize, minSize, maxSize, draggedSize) {
+      if (typeof draggedSize === 'number') {
+        const min = (typeof minSize === 'number' ? minSize : 0);
+        const max = ((typeof maxSize === 'number') && (maxSize >= 0) ? maxSize : Infinity);
+        return Math.max(min, Math.min(max, draggedSize));
+      }
+      if (defaultSize !== undefined) { return defaultSize; }
+      return minSize;
     }
   }
 
@@ -283,7 +292,9 @@ class SplitPane extends React.Component {
             this.pane1 = node;
           }}
           size={
-            primary === 'first' ? size || defaultSize || minSize : undefined
+            primary === 'first'
+              ? (size !== undefined ? size : (defaultSize !== undefined ? defaultSize : minSize))
+              : undefined
           }
           split={split}
           style={pane1Style}
@@ -312,7 +323,9 @@ class SplitPane extends React.Component {
             this.pane2 = node;
           }}
           size={
-            primary === 'second' ? size || defaultSize || minSize : undefined
+            primary === 'second'
+              ? (size !== undefined ? size : (defaultSize !== undefined ? defaultSize : minSize))
+              : undefined
           }
           split={split}
           style={pane2Style}


### PR DESCRIPTION
The current `setSize()` implementation seems to have a couple of bugs when calculating `newSize` in response to a props update:

-  The`size`, `defaultSize` and `minSize` props can be set to `0`, which should be a valid value – however this causes the current ` || ` checks to fall through because `0` is falsy. Need to check against `undefined` instead.
- If `minSize` or `maxSize` is changed, the existing `draggedSize` might fall outside the updated bounds. If an existing `draggedSize` is carried over, it should be clamped to within the incoming `minSize` / `maxSize` bounds.

This PR fixes these issues.

Points to note:

- I've replaced the existing `newSize` assignment with an ugly mess of ternary statements – depending on your style preference it might be better to extract this into a separate function
- When clamping the existing `draggedSize` value to a new `maxSize`, negative `maxSize` values will have no effect. Probably the only way to deal with this edge case gracefully would be to store the most recent `getBoundingClientRect()` value in the `onTouchMove()` method. This seemed like overkill to me.

Let me know if I can do anything to help get this merged!