### PR TITLE
Allows reversing flex direction

### DIFF
--- a/demo/Examples.js
+++ b/demo/Examples.js
@@ -597,6 +597,35 @@ const MultipleHorizontalExample = () => {
   );
 };
 
+const ReverseOrderExample = () => {
+  return (
+    <section>
+
+      <pre className="source">
+        {`
+          <SplitPane reverse>
+            <div>1</div>
+            <div>2</div>
+            <div>3</div>
+            <div>4</div>
+          </SplitPane>
+        `}
+      </pre>
+
+      <div className="example">
+
+        <SplitPane reverse>
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+          <div>4</div>
+        </SplitPane>
+
+      </div>
+    </section>
+  );
+};
+
 const SubComponentExample = () => {
   return (
     <section>
@@ -657,6 +686,7 @@ const examples = {
   BasicHorizontalExample,
   BasicVerticalExample,
   PanesAndDivsExample,
+  ReverseOrderExample,
 };
 
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,6 +38,7 @@
     <li><a href="?InitialPxVerticalExample">Initial Px Vertical</a></li>
     <li><a href="?InitialPercentageHorizontalExample">Initial Percentage Horizontal</a></li>
     <li><a href="?InitialPercentageVerticalExample">Initial Percentage Vertical</a></li>
+    <li><a href="?ReverseOrderExample">Reverse Order</a></li>
     <li><a href="?SubComponentExample">Sub Component</a></li>
   </ul>
 </nav>

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface Props {
     defaultSize?: Size;
     size?: Size;
     split?: 'vertical' | 'horizontal';
+    reverse?: boolean;
     onDragStarted?: () => void;
     onDragFinished?: () => void;
     onChange?: (newSize: number) => void;


### PR DESCRIPTION
Adds a `reverse` property allowing `row-reverse` and `column-reverse` flex directions.

This addresses an issue where moving iframes in React causes the browser to reload their content. The react team does not plan to fix this (https://github.com/facebook/react/issues/858#issuecomment-333410968) and using `flex-direction` is the only way to handle swapping columns with things like embedded media players.

---

Thanks for contributing to react-split-pane!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`yarn test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ ] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
