### PR TITLE
Move react and react-dom to peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,12 @@
       "pre-commit": "pretty-quick --staged"
     }
   },
+  "peerDependencies": {
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3"
+  },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3",
     "react-lifecycles-compat": "^3.0.4",
     "react-style-proptype": "^3.0.0"
   },


### PR DESCRIPTION
As the comment left by @vladar  on the commit (https://github.com/tomkp/react-split-pane/commit/0e3a8a0797b3ccd34f71418e89cbc432fd65c5bc) says, it's not good to have react as a straight up dependency. It can case issues with duplicate copies of react, as well as in exotic setups (such as mine), where I configure webpack for react to be available from somewhere else, but npm is installing a private copy of react-split-pane, because it thinks it is missing.