### PR TITLE
Move react and react-dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
   },
   "peerDependencies": {
     "react": "^16.0.0-0",
-    "react-dom": "^16.0.0-0",
+    "react-dom": "^16.0.0-0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3",
     "react-lifecycles-compat": "^3.0.4",
     "react-style-proptype": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -80,10 +80,16 @@
     "mochify-istanbul": "^2.4.2",
     "prettier": "1.15.3",
     "pretty-quick": "^1.8.0",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
     "rimraf": "^2.6.2",
     "rollup": "^0.60.7",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0-0",
+    "react-dom": "^16.0.0-0",
   }
 }


### PR DESCRIPTION
Both `react` and `react-dom` should be peer dependencies, so there is only one version defined in the host application. Also, notice that we need them as dev dependencies too, otherwise the build will fail.