### PR TITLE
fix: excluded react and react-dom from bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,10 @@ export default {
       format: 'esm',
     },
   ],
-  external: [...Object.keys(pkg.dependencies)],
+  external: [
+    ...Object.keys(pkg.dependencies),
+    ...Object.keys(pkg.peerDependencies),
+  ],
   plugins: [
     babel({
       exclude: 'node_modules/**',


### PR DESCRIPTION
Thanks for contributing to react-split-pane!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`yarn test`) all pass
- [N/A] For any new features or bug fixes, both positive and negative test cases have been added
- [N/A] For any new features, documentation has been added
- [N/A] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).

## Description

Updated rollup config to exclude `react` and `react-dom` from bundle. Problem was introduced in https://github.com/tomkp/react-split-pane/pull/341. I noticed this problem in our storybook.

#### Before this fix

<img width="1297" alt="Screenshot 2019-04-18 at 23 43 23" src="https://user-images.githubusercontent.com/950216/56390459-c1c14100-6234-11e9-99a6-39fa2e87c4c2.png">

#### After this fix

<img width="1043" alt="Screenshot 2019-04-18 at 23 42 01" src="https://user-images.githubusercontent.com/950216/56390455-bcfc8d00-6234-11e9-9928-eb12726240f5.png">

