### PR TITLE
added native event access for splitPanes hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 Split-Pane React component, can be nested or split vertically or horizontally. Check out some demos [here](http://react-split-pane.now.sh/)!
 
 ## Installing
+
 ```sh
 npm install react-split-pane
 
@@ -19,26 +20,28 @@ yarn add react-split-pane
 ```
 
 ## Example Usage
+
 ```jsx
- <SplitPane split="vertical" minSize={50} defaultSize={100}>
-     <div></div>
-     <div></div>
- </SplitPane>
+<SplitPane split="vertical" minSize={50} defaultSize={100}>
+  <div />
+  <div />
+</SplitPane>
 ```
 
 ```jsx
-  <SplitPane split="vertical" minSize={50}>
-      <div></div>
-      <SplitPane split="horizontal">
-          <div></div>
-          <div></div>
-      </SplitPane>
+<SplitPane split="vertical" minSize={50}>
+  <div />
+  <SplitPane split="horizontal">
+    <div />
+    <div />
   </SplitPane>
+</SplitPane>
 ```
 
 ## Props
 
 ### primary
+
 By dragging 'draggable' surface you can change size of the first pane.
 The first pane keeps then its size while the second pane is resized by browser window.
 By default it is the left pane for 'vertical' SplitPane and the top pane for 'horizontal' SplitPane.
@@ -52,13 +55,14 @@ You can also set the size of the pane using the `size` prop. Note that a size se
 In this example right pane keeps its width 200px while user is resizing browser window.
 
 ```jsx
-    <SplitPane split="vertical" defaultSize={200} primary="second">
-        <div></div>
-        <div></div>
-    </SplitPane>
+<SplitPane split="vertical" defaultSize={200} primary="second">
+  <div />
+  <div />
+</SplitPane>
 ```
 
 ### maxSize
+
 You can limit the maximal size of the 'fixed' pane using the maxSize parameter with a positive value (measured in pixels but state just a number).
 If you wrap the SplitPane into a container component (yes you can, just remember the container has to have the relative or absolute positioning),
 then you'll need to limit the movement of the splitter (resizer) at the end of the SplitPane (otherwise it can be dragged outside the SplitPane
@@ -68,30 +72,34 @@ And more: if you set the maxSize to negative value (e.g. -200), then the splitte
 size of the 'resizable' pane in this case). This can be useful also in the full-screen case of use.
 
 ### step
+
 You can use the step prop to only allow resizing in fixed increments.
 
 ### onDragStarted
+
 This callback is invoked when a drag starts.
 
 ### onDragFinished
+
 This callback is invoked when a drag ends.
 
 ### onChange
+
 This callback is invoked with the current drag during a drag event. It is recommended that it is wrapped in a debounce function.
 
 ### Inline Styles
 
 You can also pass inline styles to the components via props. These are:
 
- * `style` - Styling to be applied to the main container.
- * `paneStyle` - Styling to be applied to both panes
- * `pane1Style` - Styling to be applied to the first pane, with precedence over `paneStyle`
- * `pane2Style` - Styling to be applied to the second pane, with precedence over `paneStyle`
- * `resizerStyle` - Styling to be applied to the resizer bar
+- `style` - Styling to be applied to the main container.
+- `paneStyle` - Styling to be applied to both panes
+- `pane1Style` - Styling to be applied to the first pane, with precedence over `paneStyle`
+- `pane2Style` - Styling to be applied to the second pane, with precedence over `paneStyle`
+- `resizerStyle` - Styling to be applied to the resizer bar
 
 ## Persisting Positions
 
-Each SplitPane accepts an onChange function prop.  Used in conjunction with
+Each SplitPane accepts an onChange function prop. Used in conjunction with
 defaultSize and a persistence layer, you can ensure that your splitter choices
 survive a refresh of your app.
 
@@ -99,89 +107,92 @@ For example, if you are comfortable with the trade-offs of localStorage, you
 could do something like the following:
 
 ```jsx
-    <SplitPane split="vertical" minSize={50}
-               defaultSize={ parseInt(localStorage.getItem('splitPos'), 10) }
-               onChange={ size => localStorage.setItem('splitPos', size) }>
-        <div></div>
-        <div></div>
-    </SplitPane>
+<SplitPane
+  split="vertical"
+  minSize={50}
+  defaultSize={parseInt(localStorage.getItem('splitPos'), 10)}
+  onChange={(size, evt) => {
+    evt.stopPropagation();
+    localStorage.setItem('splitPos', size);
+  }}
+>
+  <div />
+  <div />
+</SplitPane>
 ```
 
-Disclaimer: localStorage has a variety of performance trade-offs.  Browsers such
+Disclaimer: localStorage has a variety of performance trade-offs. Browsers such
 as Firefox have now optimized localStorage use so that they will asynchronously
 initiate a read of all saved localStorage data for an origin once they know the
-page will load.  If the data has not fully loaded by the time code accesses
+page will load. If the data has not fully loaded by the time code accesses
 localStorage, the code will cause the page's main thread to block until the
-database load completes.  When the main thread is blocked, no other JS code will
-run or layout will occur.  In multiprocess browsers and for users with fast
-disk storage, this will be less of a problem.  You *are* likely to get yelled at
+database load completes. When the main thread is blocked, no other JS code will
+run or layout will occur. In multiprocess browsers and for users with fast
+disk storage, this will be less of a problem. You _are_ likely to get yelled at
 if you use localStorage.
 
 A potentially better idea is to use something like
 https://github.com/mozilla/localForage although hooking it up will be slightly
-more involved.  You are likely to be admired by all for judiciously avoiding
+more involved. You are likely to be admired by all for judiciously avoiding
 use of localStorage.
 
 ## Example styling
 
 This gives a single pixel wide divider, but with a 'grabbable' surface of 11 pixels.
 
-Thanks to ```background-clip: padding-box;``` for making transparent borders possible.
-
+Thanks to `background-clip: padding-box;` for making transparent borders possible.
 
 ```css
+.Resizer {
+  background: #000;
+  opacity: 0.2;
+  z-index: 1;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding;
+  background-clip: padding-box;
+}
 
-    .Resizer {
-        background: #000;
-        opacity: .2;
-        z-index: 1;
-        -moz-box-sizing: border-box;
-        -webkit-box-sizing: border-box;
-        box-sizing: border-box;
-        -moz-background-clip: padding;
-        -webkit-background-clip: padding;
-        background-clip: padding-box;
-    }
+.Resizer:hover {
+  -webkit-transition: all 2s ease;
+  transition: all 2s ease;
+}
 
-     .Resizer:hover {
-        -webkit-transition: all 2s ease;
-        transition: all 2s ease;
-    }
+.Resizer.horizontal {
+  height: 11px;
+  margin: -5px 0;
+  border-top: 5px solid rgba(255, 255, 255, 0);
+  border-bottom: 5px solid rgba(255, 255, 255, 0);
+  cursor: row-resize;
+  width: 100%;
+}
 
-     .Resizer.horizontal {
-        height: 11px;
-        margin: -5px 0;
-        border-top: 5px solid rgba(255, 255, 255, 0);
-        border-bottom: 5px solid rgba(255, 255, 255, 0);
-        cursor: row-resize;
-        width: 100%;
-    }
+.Resizer.horizontal:hover {
+  border-top: 5px solid rgba(0, 0, 0, 0.5);
+  border-bottom: 5px solid rgba(0, 0, 0, 0.5);
+}
 
-    .Resizer.horizontal:hover {
-        border-top: 5px solid rgba(0, 0, 0, 0.5);
-        border-bottom: 5px solid rgba(0, 0, 0, 0.5);
-    }
+.Resizer.vertical {
+  width: 11px;
+  margin: 0 -5px;
+  border-left: 5px solid rgba(255, 255, 255, 0);
+  border-right: 5px solid rgba(255, 255, 255, 0);
+  cursor: col-resize;
+}
 
-    .Resizer.vertical {
-        width: 11px;
-        margin: 0 -5px;
-        border-left: 5px solid rgba(255, 255, 255, 0);
-        border-right: 5px solid rgba(255, 255, 255, 0);
-        cursor: col-resize;
-    }
-
-    .Resizer.vertical:hover {
-        border-left: 5px solid rgba(0, 0, 0, 0.5);
-        border-right: 5px solid rgba(0, 0, 0, 0.5);
-    }
-    .Resizer.disabled {
-      cursor: not-allowed;
-    }
-    .Resizer.disabled:hover {
-      border-color: transparent;
-    }
-
- ```
+.Resizer.vertical:hover {
+  border-left: 5px solid rgba(0, 0, 0, 0.5);
+  border-right: 5px solid rgba(0, 0, 0, 0.5);
+}
+.Resizer.disabled {
+  cursor: not-allowed;
+}
+.Resizer.disabled:hover {
+  border-color: transparent;
+}
+```
 
 ## Contributing
 
@@ -191,4 +202,4 @@ Please include tests and/or update the examples if possible.
 
 **I'm working on an updated version of this library, and looking for help:** https://github.com/tomkp/react-split-pane/pull/240
 
-Thanks, Tom  
+Thanks, Tom

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,10 @@ export interface Props {
   defaultSize?: Size;
   size?: Size;
   split?: 'vertical' | 'horizontal';
-  onDragStarted?: () => void;
-  onDragFinished?: (newSize: number) => void;
-  onChange?: (newSize: number) => void;
-  onResizerClick?: (event: MouseEvent) => void;
+  onDragStarted?: (evt: TouchEvent) => void;
+  onDragFinished?: (newSize: number, evt: TouchEvent) => void;
+  onChange?: (newSize: number, evt: MouseEvent | TouchEvent) => void;
+  onResizerClick?: (event: MouseEvent, evt: MouseEvent | TouchEvent) => void;
   onResizerDoubleClick?: (event: MouseEvent) => void;
   style?: React.CSSProperties;
   resizerStyle?: React.CSSProperties;

--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -85,10 +85,10 @@ class SplitPane extends React.Component {
   }
 
   onMouseDown(event) {
-    const eventWithTouches = Object.assign({}, event, {
-      touches: [{ clientX: event.clientX, clientY: event.clientY }],
+    Object.defineProperty(event, 'touches', {
+      get: () => [{ clientX: event.clientX, clientY: event.clientY }],
     });
-    this.onTouchStart(eventWithTouches);
+    this.onTouchStart(event);
   }
 
   onTouchStart(event) {
@@ -101,7 +101,7 @@ class SplitPane extends React.Component {
           : event.touches[0].clientY;
 
       if (typeof onDragStarted === 'function') {
-        onDragStarted();
+        onDragStarted(event);
       }
       this.setState({
         active: true,
@@ -111,10 +111,10 @@ class SplitPane extends React.Component {
   }
 
   onMouseMove(event) {
-    const eventWithTouches = Object.assign({}, event, {
-      touches: [{ clientX: event.clientX, clientY: event.clientY }],
+    Object.defineProperty(event, 'touches', {
+      get: () => [{ clientX: event.clientX, clientY: event.clientY }],
     });
-    this.onTouchMove(eventWithTouches);
+    this.onTouchMove(event);
   }
 
   onTouchMove(event) {
@@ -179,7 +179,7 @@ class SplitPane extends React.Component {
             });
           }
 
-          if (onChange) onChange(newSize);
+          if (onChange) onChange(newSize, event);
 
           this.setState({
             draggedSize: newSize,
@@ -195,7 +195,7 @@ class SplitPane extends React.Component {
     const { active, draggedSize } = this.state;
     if (allowResize && active) {
       if (typeof onDragFinished === 'function') {
-        onDragFinished(draggedSize);
+        onDragFinished(draggedSize, event);
       }
       this.setState({ active: false });
     }


### PR DESCRIPTION

## Allowing access to the mouse / touch native events

Before this PR, we couldn't have a way of short circuiting events using `stopPropagation` since the API wouldn't expose the original event.

If you'd add a 'draggable' feature, the two will mix, resulting the following:

![May-05-2019 19-39-27](https://user-images.githubusercontent.com/1759539/57197991-160e3580-6f44-11e9-8433-1fa2e1c8ae9f.gif)

This PR fixes it by exposing the underlying browser event and allowing developers to stop its propagation, along with all the benefits of having native event access.

- [x] The existing test suites (`yarn test`) all pass
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).


