### PR TITLE
Fix cursor being out of sync with resize bar after hitting min/max

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -31,7 +31,7 @@ function getDefaultSize(defaultSize, minSize, maxSize, draggedSize) {
 }
 
 function removeNullChildren(children) {
-  return React.Children.toArray(children).filter(c => c);
+  return React.Children.toArray(children).filter((c) => c);
 }
 class SplitPane extends React.Component {
   constructor(props) {
@@ -166,22 +166,26 @@ class SplitPane extends React.Component {
           }
 
           let newSize = size - sizeDelta;
-          const newPosition = position - positionDelta;
+          let newPosition = position - positionDelta;
 
           if (newSize < minSize) {
+            newPosition -= isPrimaryFirst
+              ? newSize - minSize
+              : minSize - newSize;
             newSize = minSize;
           } else if (maxSize !== undefined && newSize > newMaxSize) {
+            newPosition -= isPrimaryFirst
+              ? newSize - newMaxSize
+              : newMaxSize - newSize;
             newSize = newMaxSize;
           } else {
-            this.setState({
-              position: newPosition,
-              resized: true,
-            });
+            this.setState({ resized: true });
           }
 
           if (onChange) onChange(newSize);
 
           this.setState({
+            position: newPosition,
             draggedSize: newSize,
             [isPrimaryFirst ? 'pane1Size' : 'pane2Size']: newSize,
           });
@@ -303,7 +307,7 @@ class SplitPane extends React.Component {
     return (
       <div
         className={classes.join(' ')}
-        ref={node => {
+        ref={(node) => {
           this.splitPane = node;
         }}
         style={style}
@@ -311,7 +315,7 @@ class SplitPane extends React.Component {
         <Pane
           className={pane1Classes}
           key="pane1"
-          eleRef={node => {
+          eleRef={(node) => {
             this.pane1 = node;
           }}
           size={pane1Size}
@@ -335,7 +339,7 @@ class SplitPane extends React.Component {
         <Pane
           className={pane2Classes}
           key="pane2"
-          eleRef={node => {
+          eleRef={(node) => {
             this.pane2 = node;
           }}
           size={pane2Size}


### PR DESCRIPTION
This was being caused when quickly moving the cursor past the min/max, the new position wasn't being set when hitting the min/max condition.

Example:
If minSize = 50, size = 60, sizeDelta = 20
In this can newSize would be 40 so it would hit the minSize condition to change newSize to 50 and then it would skip setting position.

With this change, it will do the same min/max logic but it will also set the position with the 10px movement.

fixes #235
