### PR TITLE
fix: Support iframe while dragging

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -253,7 +253,7 @@ class SplitPane extends React.Component {
       style: styleProps,
     } = this.props;
 
-    const { pane1Size, pane2Size } = this.state;
+    const { pane1Size, pane2Size, active } = this.state;
 
     const disabledClass = allowResize ? '' : 'disabled';
     const resizerClassNamesIncludingDefault = resizerClassName
@@ -294,8 +294,21 @@ class SplitPane extends React.Component {
 
     const classes = ['SplitPane', className, split, disabledClass];
 
-    const pane1Style = { ...paneStyle, ...pane1StyleProps };
-    const pane2Style = { ...paneStyle, ...pane2StyleProps };
+    // Prevent pointer from being captured by an iframe
+    const supportIframeStyle = {
+      pointerEvents: active ? 'none' : 'auto',
+    };
+
+    const pane1Style = {
+      ...paneStyle,
+      ...pane1StyleProps,
+      ...supportIframeStyle,
+    };
+    const pane2Style = {
+      ...paneStyle,
+      ...pane2StyleProps,
+      ...supportIframeStyle,
+    };
 
     const pane1Classes = ['Pane1', paneClassName, pane1ClassName].join(' ');
     const pane2Classes = ['Pane2', paneClassName, pane2ClassName].join(' ');


### PR DESCRIPTION
Fix #30 #241 #361 
If a pane contains an iframe, it behaves very weirdly while dragging the resizer. There are some workarounds like https://github.com/tomkp/react-split-pane/issues/30#issuecomment-169309414 https://github.com/tomkp/react-split-pane/issues/30#issuecomment-278774489 https://github.com/tomkp/react-split-pane/issues/241#issuecomment-451708777 but I think it's better if the library handles this issue itself.

I did give a comment here: https://github.com/tomkp/react-split-pane/issues/241#issuecomment-677091968

Let me know if this fix is good. Thank you.
cc: @tomkp @wuweiweiwu 