### PR TITLE
add children to typings to support removal of same in react 18 typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export type SplitPaneProps = {
   pane2Style?: React.CSSProperties;
   resizerClassName?: string;
   step?: number;
+  children?: React.ReactNode;
 };
 
 export type SplitPaneState = {


### PR DESCRIPTION
Current typing definition will cause the following error when upgrading to React 18 typing definitions
Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<SplitPane> & Pick<Readonly<SplitPaneProps>, never>

This PR adds the children prop.

See also SO answer as reference:
https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc/71809927#71809927