### PR TITLE
type declaration - fix missing `children` prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export type SplitPaneProps = {
   pane2Style?: React.CSSProperties;
   resizerClassName?: string;
   step?: number;
+  children: React.ReactNode;
 };
 
 export type SplitPaneState = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export type SplitPaneProps = {
   pane2Style?: React.CSSProperties;
   resizerClassName?: string;
   step?: number;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type SplitPaneState = {


### PR DESCRIPTION
React 18's types are more strict and the missing `children` prop results in this typescript error being thrown when using the component

```
Type '{ children: Element[]; css: SerializedStyles; split: "vertical"; minSize: number; maxSize: number; onDragStarted: () => void; onDragFinished: (newSize: number) => void; size: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<SplitPane> & { css?: Interpolation<Theme>; } & Pick<...> & InexactPartial<...> & InexactPartial<...>'.
  Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<SplitPane> & { css?: Interpolation<Theme>; } & Pick<...> & InexactPartial<...> & InexactPartial<...>'.ts(2322)
```

(anyone else running into this can use patch-package to modify `node_modules/react-split-pane/index.d.ts` in the meantime)