### PR TITLE
Add some missing props to TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,9 @@ export type SplitPaneProps = {
   onResizerDoubleClick?: (event: MouseEvent) => void;
   style?: React.CSSProperties;
   resizerStyle?: React.CSSProperties;
+  paneClassName?: string;
+  pane1ClassName?: string;
+  pane2ClassName?: string;
   paneStyle?: React.CSSProperties;
   pane1Style?: React.CSSProperties;
   pane2Style?: React.CSSProperties;


### PR DESCRIPTION
Adds the following to `SplitPaneProps`:
- `paneClassName`
- `pane1ClassName`
- `pane2ClassName`