### PR TITLE
Add checks script

### DIFF
--- a/examples/StyledExample.tsx
+++ b/examples/StyledExample.tsx
@@ -3,7 +3,15 @@ import { SplitPane, Pane } from '../src';
 import type { DividerProps } from '../src/types';
 
 function CustomDivider(props: DividerProps) {
-  const { direction, isDragging, disabled, onMouseDown, onTouchStart, onTouchEnd, onKeyDown } = props;
+  const {
+    direction,
+    isDragging,
+    disabled,
+    onMouseDown,
+    onTouchStart,
+    onTouchEnd,
+    onKeyDown,
+  } = props;
 
   return (
     <div

--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -8,7 +8,13 @@ import { SnapPointsExample } from './SnapPointsExample';
 import { PercentageExample } from './PercentageExample';
 import './styles.css';
 
-type Example = 'basic' | 'nested' | 'controlled' | 'styled' | 'snap' | 'percent';
+type Example =
+  | 'basic'
+  | 'nested'
+  | 'controlled'
+  | 'styled'
+  | 'snap'
+  | 'percent';
 
 const examples: { id: Example; label: string; shortLabel: string }[] = [
   { id: 'basic', label: 'Basic', shortLabel: 'Basic' },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format": "prettier --write src examples",
     "format:check": "prettier --check src examples",
     "typecheck": "tsc --noEmit",
+    "checks": "npm run typecheck && npm run lint && npm run format && npm run test",
     "examples": "vite --config examples/vite.config.ts",
     "examples:build": "vite build --config examples/vite.config.ts",
     "prepublishOnly": "npm run test && npm run build"


### PR DESCRIPTION
## Summary

Add a `checks` npm script that runs all validations in one command:

```bash
npm run checks
```

This runs:
- `typecheck` - TypeScript type checking
- `lint` - ESLint
- `format` - Prettier formatting
- `test` - Vitest tests

Also includes minor Prettier formatting fixes in examples.