### PR TITLE
docs: update bug report template for v3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,9 @@ Steps to reproduce the behavior:
 
 or
 
-Post a link to a [CodeSandbox](https://codesandbox.io/). You can start by forking [this one](https://codesandbox.io/s/mz305w3yoy).
+Post a link to a reproduction using [StackBlitz](https://stackblitz.com/) or [CodeSandbox](https://codesandbox.io/).
+
+> **Note:** Make sure you're using react-split-pane v3.x with the new `<Pane>` component API. See the [README](https://github.com/tomkp/react-split-pane#readme) for usage examples.
 
 #### Expected behavior
 
@@ -27,6 +29,13 @@ A clear and concise description of what you expected to happen.
 #### Screenshots
 
 If applicable, add screenshots to help explain your problem.
+
+#### Environment
+
+- react-split-pane version:
+- React version:
+- Browser:
+- OS:
 
 #### Additional context
 


### PR DESCRIPTION
## Summary

- Remove outdated v0.1.x CodeSandbox link that was using version 0.1.82
- Add note about using v3.x with the new `<Pane>` component API
- Add StackBlitz as alternative reproduction option
- Add Environment section for version information

## Context

This addresses issue #865 where the suggested CodeSandbox fork was using an outdated version (0.1.82) which caused confusion for users trying to reproduce v3 issues.

## Test plan

- [x] Linting passes
- [x] TypeScript compiles
- [x] Tests pass