### PR TITLE
fix: props of 'ThemedDivider' in TAILWIND.md

### DIFF
--- a/TAILWIND.md
+++ b/TAILWIND.md
@@ -80,10 +80,8 @@ function ThemedDivider(props: DividerProps) {
         isDragging && 'bg-primary',
         disabled && 'cursor-not-allowed opacity-50'
       )}
-    >
-      &nbsp;
-    </div>
-  )
+    />
+  );
 }
 
 <SplitPane divider={ThemedDivider}>


### PR DESCRIPTION
Currently in ThemedDivider has some wrong:

1. There needs to add `&nbsp;` in divider, or the divider will has 0 size (maybe there are better ways to do that)
2. `props.className` ( usually `undefined` ) will override the customed `className`, leding the element to have empty `className`, so I copied the logics in [example](https://github.com/tomkp/react-split-pane/blob/3a139c1a08f2af9a2b48aeadd6f0aecbb767cf37/examples/StyledExample.tsx)