### PR TITLE
feat: show version in examples header

### DIFF
--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -6,6 +6,7 @@ import { ControlledExample } from './ControlledExample';
 import { StyledExample } from './StyledExample';
 import { SnapPointsExample } from './SnapPointsExample';
 import { PercentageExample } from './PercentageExample';
+import { version } from '../package.json';
 import './styles.css';
 
 type Example =
@@ -31,7 +32,7 @@ function App() {
   return (
     <div className="app">
       <nav className="nav">
-        <h1>React Split Pane</h1>
+        <h1>React Split Pane <span className="version">v{version}</span></h1>
         <div className="nav-buttons">
           {examples.map(({ id, label, shortLabel }) => (
             <button

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -37,6 +37,12 @@ body {
   font-weight: 600;
 }
 
+.nav h1 .version {
+  font-weight: 400;
+  font-size: 0.875rem;
+  color: #888;
+}
+
 .nav-buttons {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Display the package version in the examples header
- Import version from package.json and show it next to the title
- Add subtle styling for the version text

## Test plan
- Run `npm run examples` and verify the version appears in the header