### PR TITLE
fix: avoid flicker when controlled pane sizes also change content

### DIFF
--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -14,6 +14,7 @@ import { useResizer } from '../hooks/useResizer';
 import { useKeyboardResize } from '../hooks/useKeyboardResize';
 import { convertToPixels, distributeSizes } from '../utils/calculations';
 import { cn } from '../utils/classNames';
+import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect';
 
 const DEFAULT_CLASSNAME = 'split-pane';
 const MIN_PANES = 2;
@@ -158,8 +159,9 @@ export function SplitPane(props: SplitPaneProps) {
   );
 
   // Sync paneSizes with controlled size props when they change
-  // This handles the case where parent state is reset (e.g., clicking a "Reset" button)
-  useEffect(() => {
+  // This handles the case where parent state is reset (e.g., clicking a "Reset" button).
+  // Runs in a layout effect so the new width is committed in the same paint as possible content changes.
+  useIsomorphicLayoutEffect(() => {
     if (containerSize === 0) return;
 
     // Check if any pane has a controlled size prop

--- a/src/hooks/useResizer.ts
+++ b/src/hooks/useResizer.ts
@@ -5,6 +5,7 @@ import {
   snapToPoint,
   applyStep,
 } from '../utils/calculations';
+import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect';
 
 /**
  * Options for the useResizer hook.
@@ -85,8 +86,10 @@ export function useResizer(options: UseResizerOptions): UseResizerResult {
   onResizeEndRef.current = onResizeEnd;
 
   // Sync sizes from props when not dragging (React 19 compatible)
+  // Layout effect so an external size change (e.g. a controlled pane collapsing)
+  // updates the rendered width in lockstep with consumer content.
   const sizesRef = useRef(sizes);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (
       !isDragging &&
       JSON.stringify(sizes) !== JSON.stringify(sizesRef.current)

--- a/src/utils/useIsomorphicLayoutEffect.ts
+++ b/src/utils/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,7 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` that degrades to `useEffect` during server rendering.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;


### PR DESCRIPTION
In my app, you can collapse panes to thin "sliver" windowshades; when you do that, the content also changes (to the pane's title, rendered vertically). 

Since `react-split-pane` is using `useEffect` to sync a controlled width into its state, this means the pane's content changes before the width does, leading to a flicker of about one frame where the pane's content is the vertical title, but the width is still wide.

This fixes that by using `useLayoutEffect`, when available, for that sync.